### PR TITLE
fix: send gibberish ALPS extension to avoid problems with BoringSSL

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -309,7 +309,8 @@ fn emit_client_hello_for_retry(
         }) => {
             // hack - to avoid `Unexpected Message` when communicating with BoringSSL-based servers,
             // we cannot send an actual ALPN protocol name list
-            let application_settings: PayloadU16 = PayloadU16::new(vec![0x05, 0x69, 0x6d, 0x70, 0x69, 0x74]);
+            let application_settings: PayloadU16 =
+                PayloadU16::new(vec![0x05, 0x69, 0x6d, 0x70, 0x69, 0x74]);
 
             exts.push(ClientExtension::ReservedGrease());
             exts.push(ClientExtension::SignedCertificateTimestamp());

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -307,8 +307,9 @@ fn emit_client_hello_for_retry(
             browser_type: BrowserType::Chrome,
             version: _,
         }) => {
-            // TODO: needs to actually use the data - u8-length-prefixed list of ALPN protocols
-            let application_settings: PayloadU16 = PayloadU16::new(vec![0x02, 0x68, 0x32]);
+            // hack - to avoid `Unexpected Message` when communicating with BoringSSL-based servers,
+            // we cannot send an actual ALPN protocol name list
+            let application_settings: PayloadU16 = PayloadU16::new(vec![0x05, 0x69, 0x6d, 0x70, 0x69, 0x74]);
 
             exts.push(ClientExtension::ReservedGrease());
             exts.push(ClientExtension::SignedCertificateTimestamp());


### PR DESCRIPTION
BoringSSL-based servers understand the ALPS (0x4469 or 0x44CD) TLS extension. If the client sends e.g. `h2` (showing the willingness to discuss additional HTTP2 settings), the servers try to communicate those. If the client continues the TLS handshake as usual (not further acknowledging ALPS), the server reaches an invalid state and sends a TLS alert.

Implementing full ALPS support in `rustls` is out of scope of this project.

Note that changing the ALPS values doesn't change the JA4 / JA3 fingerprints, as those only factor in the extension "names" (not the values).

Closes https://github.com/apify/impit/issues/54