### PR TITLE
fix: don't fail on received signed certificate timestamps

### DIFF
--- a/rustls/src/msgs/enums.rs
+++ b/rustls/src/msgs/enums.rs
@@ -149,7 +149,6 @@ enum_builder! {
         ReservedGrease => 0xbaba,
         DelegatedCredentials => 0x0022,
         RecordSizeLimit => 0x001c,
-        SignedCertificateTimestamp => 0x0012,
         ApplicationSettings => 0x4469,
     }
 }

--- a/rustls/src/msgs/handshake.rs
+++ b/rustls/src/msgs/handshake.rs
@@ -929,7 +929,7 @@ extension_struct! {
             pub(crate) reserved_grease: Option<()>,
 
         /// Bogus impit extension
-        ExtensionType::SignedCertificateTimestamp =>
+        ExtensionType::SCT =>
             pub(crate) signed_certificate_timestamp: Option<()>,
 
         /// Bogus impit extension
@@ -1706,6 +1706,8 @@ extension_struct! {
     pub(crate) struct CertificateExtensions<'a> {
         ExtensionType::StatusRequest =>
             pub(crate) status: Option<CertificateStatus<'a>>,
+        ExtensionType::SCT =>
+            pub(crate) signed_certificate_timestamp: Option<PayloadU16>,
     }
 }
 
@@ -1713,6 +1715,7 @@ impl CertificateExtensions<'_> {
     fn into_owned(self) -> CertificateExtensions<'static> {
         CertificateExtensions {
             status: self.status.map(|s| s.into_owned()),
+            signed_certificate_timestamp: self.signed_certificate_timestamp,
         }
     }
 }

--- a/rustls/src/msgs/handshake_test.rs
+++ b/rustls/src/msgs/handshake_test.rs
@@ -961,6 +961,7 @@ fn sample_certificate_payload_tls13() -> CertificatePayloadTls13<'static> {
                 status: Some(CertificateStatus {
                     ocsp_response: PayloadU24(Payload::new(vec![1, 2, 3])),
                 }),
+                signed_certificate_timestamp: None,
             },
         }],
     }


### PR DESCRIPTION
Emulating Chrome sends `0x0012` extension in Client Hello (`SignedCertificateTimestamp`). This prompts different servers to send the actual timestamps together with the certificate. Rustls does not expect this and fails with a TLS alert.

Closes https://github.com/apify/impit/issues/98