### PR TITLE
feat: allow ordering TLS extensions for deterministic fingerprints

### DIFF
--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -424,17 +424,22 @@ fn emit_client_hello_for_retry(
 
     #[cfg(feature = "impit")]
     if let Some(ref fingerprint) = config.tls_fingerprint {
-        if !fingerprint.extensions.extension_order.is_empty() {
-            let order = &fingerprint.extensions.extension_order;
-            exts.contiguous_extensions = order.clone();
+        if !fingerprint
+            .extensions
+            .extension_order
+            .is_empty()
+        {
+            exts.contiguous_extensions = fingerprint
+                .extensions
+                .extension_order
+                .clone();
+        }
 
-            // Suppress extensions that rustls auto-populates but the fingerprint
-            // doesn't want (e.g. TLS 1.2-only fingerprints shouldn't send
-            // supported_versions even though rustls always sets it).
-            use crate::msgs::enums::ExtensionType as ET;
-            if !order.contains(&ET::SupportedVersions) {
-                exts.supported_versions = None;
-            }
+        if !fingerprint
+            .extensions
+            .supported_versions
+        {
+            exts.supported_versions = None;
         }
     }
 

--- a/rustls/src/client/hs.rs
+++ b/rustls/src/client/hs.rs
@@ -422,6 +422,22 @@ fn emit_client_hello_for_retry(
     // but they also need to keep the same order as the previous ClientHello
     exts.order_seed = input.hello.extension_order_seed;
 
+    #[cfg(feature = "impit")]
+    if let Some(ref fingerprint) = config.tls_fingerprint {
+        if !fingerprint.extensions.extension_order.is_empty() {
+            let order = &fingerprint.extensions.extension_order;
+            exts.contiguous_extensions = order.clone();
+
+            // Suppress extensions that rustls auto-populates but the fingerprint
+            // doesn't want (e.g. TLS 1.2-only fingerprints shouldn't send
+            // supported_versions even though rustls always sets it).
+            use crate::msgs::enums::ExtensionType as ET;
+            if !order.contains(&ET::SupportedVersions) {
+                exts.supported_versions = None;
+            }
+        }
+    }
+
     #[cfg(not(feature = "impit"))]
     let mut cipher_suites: Vec<_> = config
         .provider

--- a/rustls/src/crypto/emulation/mod.rs
+++ b/rustls/src/crypto/emulation/mod.rs
@@ -3,6 +3,7 @@
 use alloc::vec::Vec;
 
 use crate::{NamedGroup, SignatureScheme, SupportedCipherSuite};
+use crate::msgs::enums::ExtensionType;
 
 use super::{WebPkiSupportedAlgorithms, aws_lc_rs};
 use webpki::aws_lc_rs as webpki_algs;
@@ -286,6 +287,10 @@ pub struct TlsExtensionsConfig {
     pub renegotiation_info: bool,
     /// Whether to send padding extension (RFC7685)
     pub padding: bool,
+    /// Explicit extension order for fingerprinting.
+    /// When non-empty, all listed extensions are emitted in this exact order
+    /// via contiguous_extensions, bypassing randomization.
+    pub extension_order: Vec<ExtensionType>,
 }
 
 /// Default signature verification algorithms.

--- a/rustls/src/crypto/emulation/mod.rs
+++ b/rustls/src/crypto/emulation/mod.rs
@@ -2,8 +2,8 @@
 #![cfg(feature = "impit")]
 use alloc::vec::Vec;
 
-use crate::{NamedGroup, SignatureScheme, SupportedCipherSuite};
 use crate::msgs::enums::ExtensionType;
+use crate::{NamedGroup, SignatureScheme, SupportedCipherSuite};
 
 use super::{WebPkiSupportedAlgorithms, aws_lc_rs};
 use webpki::aws_lc_rs as webpki_algs;
@@ -287,6 +287,10 @@ pub struct TlsExtensionsConfig {
     pub renegotiation_info: bool,
     /// Whether to send padding extension (RFC7685)
     pub padding: bool,
+    /// Whether to send supported_versions extension.
+    /// Defaults to true. Set to false for TLS 1.2-only fingerprints (e.g.
+    /// OkHttp 3) where the real client never advertises TLS 1.3 support.
+    pub supported_versions: bool,
     /// Explicit extension order for fingerprinting.
     /// When non-empty, all listed extensions are emitted in this exact order
     /// via contiguous_extensions, bypassing randomization.


### PR DESCRIPTION
`TlsExtensionsConfig` struct now accepts `extension_order: Vec<ExtensionType>` field. The extensions mentioned in this array will be present in the `ClientHello` handshake in this order (after the [randomly ordered other extensions](https://docs.rs/rustls/latest/src/rustls/msgs/handshake.rs.html#998)).