### PR TITLE
Add zlib and advertise-only 3DES handling

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -29,7 +29,7 @@ ring = ["dep:ring", "webpki/ring"]
 std = ["webpki/std", "pki-types/std", "once_cell/std"]
 tls12 = []
 zlib = ["dep:zlib-rs"]
-impit = ["aws_lc_rs", "ring", "brotli"]
+impit = ["aws_lc_rs", "ring", "brotli", "zlib"]
 
 [build-dependencies]
 rustversion = { version = "1.0.6", optional = true }

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -283,7 +283,8 @@ impl ConfigBuilder<ClientConfig, WantsClientCertWithTlsFingerprint> {
                     FingerprintCertCompressionAlgorithm::Brotli => {
                         Some(compress::BROTLI_COMPRESSOR)
                     }
-                    _ => None, // Only Brotli is supported for now
+                    FingerprintCertCompressionAlgorithm::Zlib => Some(compress::ZLIB_COMPRESSOR),
+                    _ => None, // Zstd not implemented yet
                 })
                 .collect();
             let decompressors: Vec<_> = compression
@@ -292,6 +293,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCertWithTlsFingerprint> {
                     FingerprintCertCompressionAlgorithm::Brotli => {
                         Some(compress::BROTLI_DECOMPRESSOR)
                     }
+                    FingerprintCertCompressionAlgorithm::Zlib => Some(compress::ZLIB_DECOMPRESSOR),
                     _ => None,
                 })
                 .collect();

--- a/rustls/src/crypto/emulation/mod.rs
+++ b/rustls/src/crypto/emulation/mod.rs
@@ -71,6 +71,12 @@ pub enum FingerprintCipherSuite {
     TLS_RSA_WITH_AES_256_CBC_SHA,
     TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
     TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+    // Legacy 3DES suites: advertise-only. aws-lc-rs does not implement
+    // these, so they are excluded from negotiation but their codepoints
+    // are sent in the ClientHello to match real-world fingerprints.
+    TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+    TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,
+    TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
     /// GREASE cipher suite
     Grease,
 }
@@ -119,13 +125,24 @@ impl FingerprintCipherSuite {
             Self::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA => {
                 CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
             }
+            Self::TLS_RSA_WITH_3DES_EDE_CBC_SHA => CipherSuite::TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+            Self::TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA => {
+                CipherSuite::TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA
+            }
+            Self::TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA => {
+                CipherSuite::TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+            }
             Self::Grease => CipherSuite::TLS_RESERVED_GREASE,
         }
     }
 
     /// Converts the fingerprint cipher suite to rustls's SupportedCipherSuite.
-    pub fn to_supported_cipher_suite(&self) -> SupportedCipherSuite {
-        match self {
+    ///
+    /// Returns `None` for advertise-only suites that have no aws-lc-rs
+    /// implementation (e.g. legacy 3DES). These are still emitted in the
+    /// ClientHello via [`Self::to_cipher_suite`] but cannot be negotiated.
+    pub fn to_supported_cipher_suite(&self) -> Option<SupportedCipherSuite> {
+        Some(match self {
             Self::TLS13_AES_128_GCM_SHA256 => aws_lc_rs::cipher_suite::TLS13_AES_128_GCM_SHA256,
             Self::TLS13_AES_256_GCM_SHA384 => aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
             Self::TLS13_CHACHA20_POLY1305_SHA256 => {
@@ -173,8 +190,11 @@ impl FingerprintCipherSuite {
             Self::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA => {
                 aws_lc_rs::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
             }
+            Self::TLS_RSA_WITH_3DES_EDE_CBC_SHA
+            | Self::TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA
+            | Self::TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA => return None,
             Self::Grease => aws_lc_rs::cipher_suite::TLS13_RESERVED_GREASE,
-        }
+        })
     }
 }
 

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -239,7 +239,7 @@ impl CryptoProviderBuilder {
             let cipher_suites: Vec<_> = fingerprint
                 .cipher_suites
                 .iter()
-                .map(|cs| cs.to_supported_cipher_suite())
+                .filter_map(|cs| cs.to_supported_cipher_suite())
                 .collect();
 
             // Build signature verification algorithms from the fingerprint's signature algorithms


### PR DESCRIPTION
Needed for the iOS 18 TLS profile in apify/impit#450 - the impit PR will come once this lands.

Two small additions to the `impit` feature path.

## 1. Add Zlib to the cert-compression code path

`builder.rs` previously only mapped `FingerprintCertCompressionAlgorithm::Brotli` to a real `CertCompressor`/`CertDecompressor`, with a `// Only Brotli is supported for now` TODO. Zlib and Zstd were silently dropped, which meant:

- profiles that specified `Zlib` (Firefox 133/135/144 and the new iOS profile) ended up with an empty `cert_decompressors`, so the `compress_certificate` extension was never emitted on the wire
- profiles that mixed algorithms (Firefox specifies `[Zlib, Brotli, Zstd]`) emitted only the Brotli codepoint

This PR wires Zlib through to the existing `compress::ZLIB_COMPRESSOR` / `ZLIB_DECOMPRESSOR` constants (already in the tree, just not wired). The `impit` feature now enables `zlib` so those constants are compiled in.

**Behavior change (intentional, additive):** Firefox 133/135/144 fingerprints in impit will now emit `compress_certificate` with `(zlib, brotli)` instead of dropping the extension entirely. Closer to real Firefox (which sends all three including zstd - zstd is a follow-up since the constants don't yet exist in the tree). Chrome / OkHttp / Firefox 128 are unaffected because they don't use Zlib in their profiles.

## 2. Add advertise-only 3DES cipher suite variants

iOS ClientHellos include three legacy 3DES suites in the cipher list:

- `TLS_RSA_WITH_3DES_EDE_CBC_SHA` (0x000a)
- `TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA` (0xc008)
- `TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA` (0xc012)

Without these the iOS profile's JA3 and JA4 hashes don't match a real iOS capture. The existing doc comment on `FingerprintCipherSuite::to_cipher_suite` explicitly mentions 3DES as the intended "advertise but not implement" case, so this PR completes that design:

- adds the 3 variants to `FingerprintCipherSuite`
- `to_cipher_suite()` returns their IANA codepoints from `crate::CipherSuite` (already present)
- `to_supported_cipher_suite()` now returns `Option<SupportedCipherSuite>`, returning `None` for the 3DES variants (no aws-lc-rs implementation - they can never be negotiated, only advertised in the ClientHello)
- updated the one call site in `crypto/mod.rs` to use `filter_map`

## Verification

Built locally with `--features impit`, tested via a debug build of impit-node against https://tls.peet.ws/api/all:

- iOS 18 profile (upcoming impit PR): JA3 `ecdf4f49dd59effc439639da29186671` and JA4 `t13d2013h2_a09f3c656075_7f0f34a4126d` - byte-identical to a real iPhone capture
- Chrome 142, Chrome (default), OkHttp 5, Firefox 128: JA4 unchanged
- Firefox 144: JA4 changed from the previous (silently broken) state to `t13d1717h2_5b57614c22b0_3cbfd9057e0d`, now emitting `compress_certificate` with zlib + brotli
