### PR TITLE
feat: add ML-DSA signature algorithms to fingerprint emulation

### DIFF
--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -327,6 +327,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCertWithTlsFingerprint> {
             cert_decompressors,
             cert_compression_cache: Arc::new(compress::CompressionCache::default()),
             ech_mode: self.state.client_ech_mode,
+            send_ticket_request: None,
         }
     }
 }

--- a/rustls/src/crypto/emulation/mod.rs
+++ b/rustls/src/crypto/emulation/mod.rs
@@ -254,6 +254,10 @@ pub enum FingerprintSignatureAlgorithm {
     // EdDSA algorithms
     Ed25519,
     Ed448,
+    // ML-DSA algorithms (draft-ietf-tls-mldsa)
+    MlDsa44,
+    MlDsa65,
+    MlDsa87,
     // Legacy
     EcdsaSha1Legacy,
 }
@@ -274,6 +278,9 @@ impl FingerprintSignatureAlgorithm {
             Self::RsaPkcs1Sha1 => SignatureScheme::RSA_PKCS1_SHA1,
             Self::Ed25519 => SignatureScheme::ED25519,
             Self::Ed448 => SignatureScheme::ED448,
+            Self::MlDsa44 => SignatureScheme::ML_DSA_44,
+            Self::MlDsa65 => SignatureScheme::ML_DSA_65,
+            Self::MlDsa87 => SignatureScheme::ML_DSA_87,
             Self::EcdsaSha1Legacy => SignatureScheme::ECDSA_SHA1_Legacy,
         }
     }
@@ -416,6 +423,9 @@ impl FingerprintSignatureAlgorithm {
             Self::Ed25519 => ED25519_ALGS,
             // Ed448 is not supported by webpki, SHA1 legacy uses fallback in mapping
             Self::Ed448 | Self::RsaPkcs1Sha1 | Self::EcdsaSha1Legacy => EMPTY,
+            // ML-DSA is advertised to match browsers that offer it, but webpki has
+            // no verifier for it, so it contributes nothing to certificate validation.
+            Self::MlDsa44 | Self::MlDsa65 | Self::MlDsa87 => EMPTY,
         }
     }
 
@@ -457,6 +467,21 @@ impl FingerprintSignatureAlgorithm {
         static ECDSA_SHA1_FALLBACK: &[&dyn pki_types::SignatureVerificationAlgorithm] =
             &[webpki_algs::ECDSA_P256_SHA256];
         static ED25519: &[&dyn pki_types::SignatureVerificationAlgorithm] = &[webpki_algs::ED25519];
+        // ML-DSA is advertised for fingerprint accuracy but webpki has no verifier
+        // for it. The mapping doubles as the list of schemes we offer, so the entry
+        // has to exist; it must also be non-empty, because the TLS 1.3 verify path
+        // indexes the first element. This placeholder can never validate an ML-DSA
+        // signature, so a server that actually selects one fails the handshake
+        // cleanly instead of panicking.
+        //
+        // Ed25519 rather than a P-256 verifier: the placeholder does get run, so a
+        // server whose certificate key matches it could have a CertificateVerify
+        // mislabelled as ML-DSA accepted. Only the legitimate key holder can produce
+        // such a signature, but P-256 is the common case for publicly-trusted server
+        // certificates whereas Ed25519 is not issued by public CAs, so this keeps the
+        // window as small as the fallback approach allows.
+        static ML_DSA_FALLBACK: &[&dyn pki_types::SignatureVerificationAlgorithm] =
+            &[webpki_algs::ED25519];
 
         match self {
             Self::EcdsaSecp256r1Sha256 => {
@@ -481,6 +506,9 @@ impl FingerprintSignatureAlgorithm {
             Self::Ed25519 => Some((SignatureScheme::ED25519, ED25519)),
             // Ed448 is not supported
             Self::Ed448 => None,
+            Self::MlDsa44 => Some((SignatureScheme::ML_DSA_44, ML_DSA_FALLBACK)),
+            Self::MlDsa65 => Some((SignatureScheme::ML_DSA_65, ML_DSA_FALLBACK)),
+            Self::MlDsa87 => Some((SignatureScheme::ML_DSA_87, ML_DSA_FALLBACK)),
         }
     }
 }


### PR DESCRIPTION
Adds the three ML-DSA signature algorithm codepoints from [draft-ietf-tls-mldsa](https://datatracker.ietf.org/doc/draft-ietf-tls-mldsa/) to the fingerprint emulation layer, so an emulated fingerprint can advertise them.

Prerequisite for apify/impit#508 — Chrome 150+ leads its ClientHello `signature_algorithms` list with `0x0904`/`0x0905`/`0x0906`, and that is the entire reason `chrome142` produces a different JA4 from current Chrome. The `SignatureScheme::ML_DSA_44/65/87` constants already existed in `enums.rs`; only the emulation plumbing was missing. The impit-side PR adding the `chrome151` profile will follow once this lands and the `rev` pin can be bumped.

### Two things here are easy to get wrong

Both are commented in the code, because a future cleanup would plausibly "simplify" either one and reintroduce the problem.

**The mapping is the advertise list.** `to_mapping_entry()` feeds `WebPkiSupportedAlgorithms.mapping`, which becomes `supported_schemes()` and thus the ClientHello extension. Following the `Ed448` precedent and returning `None` compiles fine and silently emits nothing — I hit exactly that, and the JA4 came back identical to `chrome142`. Note `to_signature_scheme()` has no callers; it does not put anything on the wire.

**The mapped slice must be non-empty.** `verify_tls13_signature` does `convert_scheme(dss.scheme)?[0]`, and `supported_in_tls13()` is a denylist that lets ML-DSA through, so an empty slice would be an index-out-of-bounds panic reachable from a misbehaving server. Hence the placeholder verifier.

`Ed25519` was chosen as that placeholder deliberately. It can never validate a genuine ML-DSA signature, so a server selecting one fails the handshake cleanly. Because the placeholder does get run, a server whose certificate key matches it could in principle have a `CertificateVerify` mislabelled as ML-DSA accepted — only by the legitimate key holder, but the window is real. P-256 is the common case for publicly-trusted server certs; Ed25519 is not issued by public CAs, so this keeps that window as small as the fallback approach allows. The same pattern already exists for the SHA-1 schemes (`RsaPkcs1Sha1`, `EcdsaSha1Legacy`), though those are unreachable in TLS 1.3 — ML-DSA is the first one that isn't.

If you would rather not carry that tradeoff, the alternative is changing `verify.rs:198`/`:220` to `.first().ok_or(...)` and mapping ML-DSA to an empty slice. That is fail-closed and strictly cleaner, but it puts a delta in core `verify.rs` and so permanent merge friction against upstream. Happy to switch if you prefer it.

### The `send_ticket_request` commit

`impit-main` does not currently compile — the merge of upstream `v/0.23.43` added `ClientConfig::send_ticket_request` and updated the default builder, but the parallel initializer under `#[cfg(feature = "impit")]` was missed:

```
error[E0063]: missing field `send_ticket_request` in initializer of `ClientConfig`
  --> rustls/src/client/builder.rs:309
```

Included as a separate first commit so it is reviewable (or cherry-pickable) on its own, and so the branch builds at every commit. It defaults to `None`, matching the field's documented default and the non-impit builder twenty lines above, so no `ticket_request` extension is sent and emulated ClientHellos are unchanged.

Separately and not addressed here: the `examples` workspace member has a stale lockfile (`zerovec` pinned 0.11.5, `icu_normalizer 2.2.0` wants `^0.11.6`), which fails `cargo build` workspace-wide. Left alone since it needs a `Cargo.lock` change and renovate manages deps here, but flagging it in case CI goes red for that reason.

### Verification

Built against a local `impit` with a `chrome151` profile listing these three algorithms first, requesting `https://tls.peet.ws/api/all`:

| | JA4 |
| --- | --- |
| Real Chrome 151.0.7922.72 | `t13d1516h2_8daaf6152771_806a8c22fdea` |
| impit with this change | `t13d1516h2_8daaf6152771_806a8c22fdea` |
| impit `chrome142` today | `t13d1516h2_8daaf6152771_d8a2da3f94cd` |

`ja4_r` is byte-identical to the browser, sigalgs included:

```
t13d1516h2_002f,...,cca9_0005,...,ff01_0904,0905,0906,0403,0804,0401,0503,0805,0501,0806,0601
```

A real HTTPS request completes with status 200 while ML-DSA is advertised, so nothing in the handshake or certificate-verification path rejects it.

### Caveats

- The draft is IESG-approved but **not yet an RFC**; IANA lists all three with Recommended=`N` and the action state on hold. The codepoint values are unchanged across draft `-00` through `-05` and already ship in BoringSSL and Chrome 150+, so they are stable in practice.
- **Advertise-only.** `to_webpki_algs()` returns `EMPTY`, so these contribute nothing to chain validation. Real Chrome genuinely verifies ML-DSA end-to-end; against a server presenting an ML-DSA certificate this client fails the handshake cleanly where Chrome would succeed. Not reachable on the public web today — no publicly-trusted CA issues ML-DSA TLS certificates.
